### PR TITLE
UI-015: Make admins be able to create any kind of token

### DIFF
--- a/src/lib/api/token/token.ts
+++ b/src/lib/api/token/token.ts
@@ -68,3 +68,9 @@ export async function updateToken(
     request,
   );
 }
+
+// -----------------------------------------------------------------
+
+export async function getAllTokens(): Promise<ApiResult<GetTokensResponse>> {
+  return sendRequestWithAuth<never, GetTokensResponse>("GET", `/tokens`);
+}


### PR DESCRIPTION
This pull request adds admin capabilities to the tokens management page, allowing admins to view and manage tokens for all teams, not just their own. The UI and logic are updated to support team selection for token creation, group tokens by team for admin views, and ensure correct permissions and error handling for both admins and regular users.

**Admin functionality and UI enhancements:**

* Added admin detection and logic throughout `TokensPage`, allowing admins to fetch all tokens and teams, and select the target team when creating a token.
* Updated the token creation dialog for admins to include a team selection dropdown, with validation requiring a team to be selected.
* Added a new admin view that groups tokens by team, displays team badges, and supports admin actions for all tokens.
* Updated informational text and empty states to reflect admin capabilities and clarify token ownership.

**API integration:**

* Added `getAllTokens` API function to fetch all tokens for admin use.

**Token management logic:**

* Refactored token creation and deletion logic to ensure admins can specify the team, while regular users are restricted to their own team.

These changes ensure that admins have full visibility and control over tokens across all teams, while regular users retain access only to their own team's tokens.